### PR TITLE
ci: pin to rc3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
 
       - name: Setup wash CLI
         uses: wasmcloud/setup-wash-action@v1.0.0-rc.3
+        with:
+          wash-version: "wash-v1.0.0-rc.3"
 
       - name: Build component
         uses: wasmcloud/actions/wash-build@v0.2.0


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Pins `wash` CLI version in CI to `wash-v1.0.0-rc.3`.
> 
> - **CI**
>   - Workflow `.github/workflows/ci.yml`:
>     - Setup wash CLI: add `with.wash-version: "wash-v1.0.0-rc.3"`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b5afeffae9bd4c2aadb610ee0a72b24a2e200f11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->