### PR TITLE
fix: Pinning wash version temporarily

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup wash CLI
         uses: wasmcloud/setup-wash-action@v1.0.0-rc.3
         with:
-          wash-version: wash-1.0.0-rc.1
+          wash-version: wash-v1.0.0-beta.10
 
       - name: Build component
         uses: wasmcloud/actions/wash-build@v0.2.0


### PR DESCRIPTION
Pinning wash version until https://github.com/wasmCloud/wash/pull/192 is released.