### PR TITLE
ci: pin to latest wash

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Setup wash CLI
         uses: wasmcloud/setup-wash-action@v1.0.0-rc.3
         with:
-          wash-version: wash-v1.0.0-beta.10
+          wash-version: wash-v2.0.0-rc.4
 
       - name: Build component
         uses: wasmcloud/actions/wash-build@v0.2.0

--- a/README.md
+++ b/README.md
@@ -17,9 +17,8 @@ wash plugin install ghcr.io/cosmonic-labs/plugins/openapi2mcp:0.5.0
 Start with an MCP project, using our template to get started:
 
 ```shell
-wash new --git https://github.com/cosmonic-labs/mcp-server-template-ts.git "my-mcp-server"
+wash new https://github.com/cosmonic-labs/mcp-server-template-ts.git "my-mcp-server"
 ```
-
 Generate MCP tools into the server project from an OpenAPI specification:
 
 ```shell
@@ -32,7 +31,7 @@ wash openapi2mcp [path/to/open/yaml/or/json] --project-path [path/to/generated/m
 
 ```shell
 # cargo run -- -i [path/to/open/yaml/or/json] --project-path [path/to/generated/mcp/server]
-wash new --git https://github.com/cosmonic-labs/mcp-server-template-ts.git "tests/petstore/generated"
+wash new https://github.com/cosmonic-labs/mcp-server-template-ts.git "tests/petstore/generated"
 cargo run -- -i tests/petstore/input.json --project-path tests/petstore/generated
 ```
 
@@ -54,6 +53,6 @@ Run as `wash` plugin:
 
 ```shell
 # wash openapi2mcp [path/to/open/yaml/or/json] --project-path [path/to/generated/mcp/server]
-wash new --git https://github.com/cosmonic-labs/mcp-server-template-ts.git tests/petstore/generated
+wash new https://github.com/cosmonic-labs/mcp-server-template-ts.git tests/petstore/generated
 wash openapi2mcp tests/petstore/input.json --project-path tests/petstore/generated
 ```

--- a/scripts/test-e2e.sh
+++ b/scripts/test-e2e.sh
@@ -63,7 +63,7 @@ for dir in ./tests/*/ ; do
 
     # Generate MCP server code
     echo "Generating MCP server from $spec_file..."
-    wash new --git https://github.com/cosmonic-labs/mcp-server-template-ts.git "$dir/generated"
+    wash new https://github.com/cosmonic-labs/mcp-server-template-ts.git --name "$dir/generated"
     wash openapi2mcp "$spec_file" --project-path "$dir/generated"
     if [ $? -ne 0 ]; then
         echo "Error: Failed to generate MCP server from $spec_file"


### PR DESCRIPTION
Signed-off-by: ricohet <bailey@cosmonic.com>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Update to wash v2.0.0-rc.4 and align docs/tests with new `wash new` CLI syntax.
> 
> - **CI**:
>   - Bump `wash` CLI in `.github/workflows/ci.yml` to `wash-v2.0.0-rc.4`.
> - **Docs**:
>   - Update `README.md` examples to new `wash new` syntax (remove `--git`).
> - **Scripts/Tests**:
>   - Adjust `scripts/test-e2e.sh` to use new `wash new https://... --name <dir>` invocation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c93b03238c2382c92cfe78c2c42f244d58e18002. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->